### PR TITLE
fix(viewer): colors for badge and circle for players differs

### DIFF
--- a/viewer/components/Game.tsx
+++ b/viewer/components/Game.tsx
@@ -142,6 +142,7 @@ export function Game() {
         offScreenContext.fillStyle = playerColor
         offScreenContext.strokeStyle = 'black'
         offScreenContext.lineWidth = 2
+        offScreenContext.beginPath()
         offScreenContext.rect(nameX, nameY, nameMetrics.width + 10, textHeight + 10)
         offScreenContext.fill()
         offScreenContext.stroke()


### PR DESCRIPTION
Fixes the inconsistent drawing behavior from #8

<img width="642" alt="image" src="https://user-images.githubusercontent.com/4036376/171868658-25003aad-5bd6-469c-a23d-3ada3da9427b.png">
